### PR TITLE
make sure users can't deploy this module with aws provider 6.28 because it breaks this module

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.34, < 6.28"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
There are still use cases for v1.0.2 of this module, the updated provider declaration makes sure users don't try to run it with version 6.28 of the AWS provider that breaks it.
I would advertise this as v1.0.3